### PR TITLE
p.465 예제15.4 with-meta 인자 수정

### DIFF
--- a/src/clj/ch15/joy/memoization.clj
+++ b/src/clj/ch15/joy/memoization.clj
@@ -54,7 +54,7 @@
 (defn memoization-impl [cache-impl]
   (let [cache (atom cache-impl)]
     (with-meta
-      (fn [$ args]
+      (fn [& args]
         (let [cs (swap! cache through (.f cache-impl) args)]
           @(lookup cs args)))
       {:cache cache})))


### PR DESCRIPTION
$는 인자 오류가 발생되고 실행되지 않으며
문맥상 &가 맞으며 동작합니다.